### PR TITLE
Tentative fix for crash on host computer when socket cannot be connected.

### DIFF
--- a/piscope.c
+++ b/piscope.c
@@ -1729,7 +1729,9 @@ static gboolean main_util_input(gpointer user_data)
 
       FD_ZERO(&fds);
 
-      FD_SET(gPigNotify, &fds);
+      if (!gPigNotify < 0){
+         FD_SET(gPigNotify, &fds);
+      }
 
       if (select(gPigNotify+1, &fds, NULL, NULL, &tv) != 1) break;
 


### PR DESCRIPTION
While trying to compile and run for desktop (on Linux Mint), the following line crashed:

``` c
FD_SET(gPigNotify, &fds);
```

Looks like it is due to `gPigNotify` being `-1` since this was on a host computer, not on the Raspi itself. Same crash occurs if the hostname or IP given isn't found:

``` bash
PIGPIO_ADDR=the-pie-is-a-lie ./piscope
```
