### PR TITLE
added buttons to the GPIO dialog: "Clear All" and "Set All"

### DIFF
--- a/piscope.c
+++ b/piscope.c
@@ -1228,6 +1228,34 @@ static int file_save(int filetype, char *filename, int selection)
 
 /* GPIO ------------------------------------------------------------------- */
 
+void gpio_clear_all(GtkButton * button, gpointer user_data)
+{
+   int i;
+   /* set states */
+   for (i=0; i<PISCOPE_GPIOS; i++)
+   {
+      gGpioInfo[i].hilit = 0;
+      gtk_toggle_button_set_active(gGpioInfo[i].button, FALSE);
+   }
+
+   util_vlegConfigure(gMainCvleg);
+   gtk_widget_queue_draw(gMainCvleg);
+}
+
+void gpio_set_all(GtkButton * button, gpointer user_data)
+{
+   int i;
+   /* set states */
+   for (i=0; i<PISCOPE_GPIOS; i++)
+   {
+      gGpioInfo[i].hilit = !0;
+      gtk_toggle_button_set_active(gGpioInfo[i].button, TRUE);
+   }
+
+   util_vlegConfigure(gMainCvleg);
+   gtk_widget_queue_draw(gMainCvleg);
+}
+
 void gpio_apply_clicked(GtkButton * button, gpointer user_data)
 {
    int i;

--- a/piscope.glade
+++ b/piscope.glade
@@ -325,6 +325,36 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
+              <object class="GtkButton" id="gpio_clear_all">
+                <property name="label">Clear All</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="gpio_clear_all" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="gpio_set_all">
+                <property name="label">Set All</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="gpio_set_all" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="gpio_cancel">
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
@@ -336,7 +366,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -351,7 +381,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
makes it faster to select only a few GPIOs for monitoring

Signed-off-by: hayati ayguen <h_ayguen@web.de>