### PR TITLE
Save settings to user's config directory

### DIFF
--- a/README
+++ b/README
@@ -50,13 +50,6 @@ sudo pigpiod # launch the pigpio daemon
 
 # If running piscope on another machine
 
-export PIGPIO_ADDR=host # where host is the Pi's hostname
-
-# or
-
-export PIGPIO_ADDR=x.x.x.x # where x.x.x.x is the Pi's IP address.
-
-# then
-
 piscope &
 
+then set the address and port of the machine running pigpiod in the preferences dialog

--- a/README
+++ b/README
@@ -48,8 +48,21 @@ make install
 
 sudo pigpiod # launch the pigpio daemon
 
-# If running piscope on another machine
+# If running piscope on another machine you have 2 ways to connect:
 
-piscope &
+1) Set the remote address via environment variables BEFORE launching piscope:
+  export PIGPIO_ADDR=host # where host is the Pi's hostname
 
-then set the address and port of the machine running pigpiod in the preferences dialog
+  # or
+
+  export PIGPIO_ADDR=x.x.x.x # where x.x.x.x is the Pi's IP address.
+
+  # then
+
+  piscope &
+
+2) Set the remote address in the preferences dialog
+  piscope &
+
+  # then open the preferences dialog and set Pi's hostname/address
+  # (Note: if set, the PIGPIO_ADDR environment variable takes always the precedence)

--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ Pi captures data, Pi processes data, remote displays data
 On a remote machine
 -------------------
 
-remote_host ~ $ export PIGPIO_ADDR=pi_host
-
 remote_host ~ $ piscope
 
+Then, in the preferences dialog, set the address/hostname and port of the machine running pigpio.
 Pi captures data, remote processes data, remote displays data
 
 OPERATING MODES

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ Pi captures data, Pi processes data, remote displays data
 On a remote machine
 -------------------
 
+remote_host ~ $ export PIGPIO_ADDR=pi_host
+
 remote_host ~ $ piscope
 
-Then, in the preferences dialog, set the address/hostname and port of the machine running pigpio.
+Alternatively, you can avoid setting the PIGPIO_ADDR environment variable and set the server hostname/address in the preferences dialog.
+(Note: if set, the PIGPIO_ADDR environment variables takes always the precedence)
 Pi captures data, remote processes data, remote displays data
 
 OPERATING MODES

--- a/piscope.c
+++ b/piscope.c
@@ -828,7 +828,7 @@ static void pigpioLoadSettings(void)
    gsize len;
 
    cfg = g_key_file_new();
-   file = g_build_filename(g_get_user_config_dir(), "piscope.conf", NULL);
+   file = g_build_filename(g_get_user_config_dir(), SETTINGS_FILE_NAME, NULL);
 
    loaded = g_key_file_load_from_file(cfg, file, G_KEY_FILE_NONE, NULL);
 
@@ -840,18 +840,18 @@ static void pigpioLoadSettings(void)
 
    if(loaded)
    {
-      gSettings.serverAddress = g_key_file_get_string(cfg, "Settings", "serverAddress", NULL);
-      gSettings.activeGPIOs = g_key_file_get_integer_list (cfg, "Settings", "activeGPIOs", &gSettings.activeGPIOCount, NULL);
-      gSettings.port = g_key_file_get_integer(cfg, "Settings", "serverPort", NULL);
-      gSettings.triggerSamples = g_key_file_get_integer(cfg, "Settings", "triggerSamples", NULL);
+      gSettings.serverAddress = g_key_file_get_string(cfg, SETTINGS_GROUP, SETTINGS_SERVER_ADDRESS, NULL);
+      gSettings.activeGPIOs = g_key_file_get_integer_list (cfg, SETTINGS_GROUP, SETTINGS_ACTIVE_GPIOS, &gSettings.activeGPIOCount, NULL);
+      gSettings.port = g_key_file_get_integer(cfg, SETTINGS_GROUP, SETTINGS_SERVER_PORT, NULL);
+      gSettings.triggerSamples = g_key_file_get_integer(cfg, SETTINGS_GROUP, SETTINGS_TRIGGER_SAMPLES, NULL);
       for(i=0; i<PISCOPE_TRIGGERS; i++)
          {
-            sprintf(buf, "trigger%dEnabled", i+1);
-            gSettings.triggers[i].enabled = g_key_file_get_boolean(cfg, "Settings", buf, NULL);
-            sprintf(buf, "trigger%dAction", i+1);
-            gSettings.triggers[i].action = g_key_file_get_integer(cfg, "Settings", buf, NULL);
-            sprintf(buf, "trigger%dGPIOTypes", i+1);
-            tempList = g_key_file_get_integer_list(cfg, "Settings", buf, &len, NULL);
+            sprintf(buf, SETTINGS_TRIGGER_ENABLED, i+1);
+            gSettings.triggers[i].enabled = g_key_file_get_boolean(cfg, SETTINGS_GROUP, buf, NULL);
+            sprintf(buf, SETTINGS_TRIGGER_ACTION, i+1);
+            gSettings.triggers[i].action = g_key_file_get_integer(cfg, SETTINGS_GROUP, buf, NULL);
+            sprintf(buf, SETTINGS_TRIGGER_GPIO_TYPES, i+1);
+            tempList = g_key_file_get_integer_list(cfg, SETTINGS_GROUP, buf, &len, NULL);
             if(tempList)
                {
                   for(j=0; j<len && j<PISCOPE_GPIOS; j++)
@@ -881,22 +881,22 @@ static void pigpioSaveSettings(void)
    int i;
 
    cfg = g_key_file_new();
-   file = g_build_filename(g_get_user_config_dir(), "piscope.conf", NULL);
+   file = g_build_filename(g_get_user_config_dir(), SETTINGS_FILE_NAME, NULL);
 
-   g_key_file_set_string(cfg, "Settings", "serverAddress", gSettings.serverAddress);
-   g_key_file_set_integer(cfg, "Settings", "serverPort", gSettings.port);
+   g_key_file_set_string(cfg, SETTINGS_GROUP, SETTINGS_SERVER_ADDRESS, gSettings.serverAddress);
+   g_key_file_set_integer(cfg, SETTINGS_GROUP, SETTINGS_SERVER_PORT, gSettings.port);
    if(gSettings.activeGPIOs)
-      g_key_file_set_integer_list(cfg, "Settings", "activeGPIOs", gSettings.activeGPIOs, gSettings.activeGPIOCount);
+      g_key_file_set_integer_list(cfg, SETTINGS_GROUP, SETTINGS_ACTIVE_GPIOS, gSettings.activeGPIOs, gSettings.activeGPIOCount);
 
-   g_key_file_set_integer(cfg, "Settings", "triggerSamples", gSettings.triggerSamples);
+   g_key_file_set_integer(cfg, SETTINGS_GROUP, SETTINGS_TRIGGER_SAMPLES, gSettings.triggerSamples);
    for(i=0; i<PISCOPE_TRIGGERS; i++)
       {
-         sprintf(buf, "trigger%dEnabled", i+1);
-         g_key_file_set_boolean(cfg, "Settings", buf, gSettings.triggers[i].enabled);
-         sprintf(buf, "trigger%dAction", i+1);
-         g_key_file_set_integer(cfg, "Settings", buf, gSettings.triggers[i].action);
-         sprintf(buf, "trigger%dGPIOTypes", i+1);
-         g_key_file_set_integer_list(cfg, "Settings", buf, gSettings.triggers[i].gpiotypes, PISCOPE_GPIOS);
+         sprintf(buf, SETTINGS_TRIGGER_ENABLED, i+1);
+         g_key_file_set_boolean(cfg, SETTINGS_GROUP, buf, gSettings.triggers[i].enabled);
+         sprintf(buf, SETTINGS_TRIGGER_ACTION, i+1);
+         g_key_file_set_integer(cfg, SETTINGS_GROUP, buf, gSettings.triggers[i].action);
+         sprintf(buf, SETTINGS_TRIGGER_GPIO_TYPES, i+1);
+         g_key_file_set_integer_list(cfg, SETTINGS_GROUP, buf, gSettings.triggers[i].gpiotypes, PISCOPE_GPIOS);
       }
    g_key_file_save_to_file(cfg, file, NULL);
 

--- a/piscope.c
+++ b/piscope.c
@@ -36,16 +36,7 @@ On the Pi you need to
 sudo pigpiod # to start the pigpio daemon
 
 If you are running piscope remotely (i.e. not on the Pi running pigpiod)
-you need to set the environment variable PIGPIO_ADDR to specify the
-machine running pigpiod.
-
-e.g.
-
-export PIGPIO_ADDR=soft # specify by host name
-
-or
-
-export PIGPIO_ADDR=192.168.1.67 # specify by IP address
+you need to set the address/hostname and port of machine running pigpiod in the preferences dialog.
 
 */
 
@@ -180,6 +171,22 @@ typedef struct
    char *name;
 } piscopeGpioUsage_t;
 
+typedef struct
+{
+   gboolean enabled;
+   gint action;
+   gint gpiotypes[PISCOPE_GPIOS];
+} piscopeTriggerSettings_t;
+
+typedef struct
+{
+   gchar *serverAddress;
+   gint  *activeGPIOs;
+   gsize activeGPIOCount;
+   gint  port;
+   gint triggerSamples;
+   piscopeTriggerSettings_t triggers[PISCOPE_TRIGGERS];
+} piscopeSettings_t;
 
 /* GLOBALS ---------------------------------------------------------------- */
 
@@ -360,6 +367,8 @@ static cairo_surface_t  *gCsampSurface = NULL;
 static cairo_surface_t  *gCmodeSurface    = NULL;
 
 static cairo_t          *gCoscCairo = NULL;
+
+static piscopeSettings_t gSettings;
 
 gboolean main_osc_configure_event
 (
@@ -760,7 +769,7 @@ static char *util_timeStamp(int64_t *tick, int decimals, int blue)
       gtk_label_set_text((GtkLabel*)gMainLblue, blueBuf);
    }
 
-   timeradd(&gTimeOrigin, &offsetTime, &now);   
+   timeradd(&gTimeOrigin, &offsetTime, &now);
 
    if (now.tv_sec != last.tv_sec)
    {
@@ -802,27 +811,101 @@ static int pigpioCommand(int fd, int command, int p1, int p2)
 
 static void pigpioSetAddr(void)
 {
-   char * portStr, * addrStr;
-   char buf[16];
+   char portStr[16];
+   sprintf(portStr, "%d", gSettings.port);
 
-   portStr = getenv(PI_ENVPORT);
-
-   if ((!portStr) || (!strlen(portStr)))
-   {
-      sprintf(buf, "%d", PI_DEFAULT_SOCKET_PORT);
-      portStr = buf;
-   }
-
-   addrStr = getenv(PI_ENVADDR);
-
-   if ((!addrStr) || (!strlen(addrStr)))
-   {
-      addrStr="127.0.0.1";
-   }
-
-   gtk_entry_set_text(GTK_ENTRY(gCmdsPigpioAddr), addrStr);
-
+   gtk_entry_set_text(GTK_ENTRY(gCmdsPigpioAddr), gSettings.serverAddress);
    gtk_entry_set_text(GTK_ENTRY(gCmdsPigpioPort), portStr);
+}
+
+static void pigpioLoadSettings(void)
+{
+   GKeyFile *cfg;
+   char *file, buf[50];
+   gint *tempList;
+   gboolean loaded;
+   int i, j;
+   gsize len;
+
+   cfg = g_key_file_new();
+   file = g_build_filename(g_get_user_config_dir(), "piscope.conf", NULL);
+
+   loaded = g_key_file_load_from_file(cfg, file, G_KEY_FILE_NONE, NULL);
+
+   g_free(gSettings.serverAddress);
+   g_free(gSettings.activeGPIOs);
+   gSettings.serverAddress=NULL;
+   gSettings.activeGPIOs=NULL;
+   gSettings.activeGPIOCount=0;
+
+   if(loaded)
+   {
+      gSettings.serverAddress = g_key_file_get_string(cfg, "Settings", "serverAddress", NULL);
+      gSettings.activeGPIOs = g_key_file_get_integer_list (cfg, "Settings", "activeGPIOs", &gSettings.activeGPIOCount, NULL);
+      gSettings.port = g_key_file_get_integer(cfg, "Settings", "serverPort", NULL);
+      gSettings.triggerSamples = g_key_file_get_integer(cfg, "Settings", "triggerSamples", NULL);
+      for(i=0; i<PISCOPE_TRIGGERS; i++)
+         {
+            sprintf(buf, "trigger%dEnabled", i+1);
+            gSettings.triggers[i].enabled = g_key_file_get_boolean(cfg, "Settings", buf, NULL);
+            sprintf(buf, "trigger%dAction", i+1);
+            gSettings.triggers[i].action = g_key_file_get_integer(cfg, "Settings", buf, NULL);
+            sprintf(buf, "trigger%dGPIOTypes", i+1);
+            tempList = g_key_file_get_integer_list(cfg, "Settings", buf, &len, NULL);
+            if(tempList)
+               {
+                  for(j=0; j<len && j<PISCOPE_GPIOS; j++)
+                     {
+                        gSettings.triggers[i].gpiotypes[j] = tempList[j];
+                     }
+               }
+            g_free(tempList);
+         }
+   }
+
+   if(!gSettings.serverAddress)
+   {
+      gSettings.serverAddress = g_malloc(sizeof(PI_DEFAULT_SERVER_ADDRESS));
+      strcpy (gSettings.serverAddress, PI_DEFAULT_SERVER_ADDRESS);
+      gSettings.port = PI_DEFAULT_SOCKET_PORT;
+   }
+
+   g_free(file);
+   g_key_file_free(cfg);
+}
+
+static void pigpioSaveSettings(void)
+{
+   GKeyFile * cfg;
+   char * file, buf[50];
+   int i;
+
+   cfg = g_key_file_new();
+   file = g_build_filename(g_get_user_config_dir(), "piscope.conf", NULL);
+
+   g_key_file_set_string(cfg, "Settings", "serverAddress", gSettings.serverAddress);
+   g_key_file_set_integer(cfg, "Settings", "serverPort", gSettings.port);
+   if(gSettings.activeGPIOs)
+      g_key_file_set_integer_list(cfg, "Settings", "activeGPIOs", gSettings.activeGPIOs, gSettings.activeGPIOCount);
+
+   g_key_file_set_integer(cfg, "Settings", "triggerSamples", gSettings.triggerSamples);
+   for(i=0; i<PISCOPE_TRIGGERS; i++)
+      {
+         sprintf(buf, "trigger%dEnabled", i+1);
+         g_key_file_set_boolean(cfg, "Settings", buf, gSettings.triggers[i].enabled);
+         sprintf(buf, "trigger%dAction", i+1);
+         g_key_file_set_integer(cfg, "Settings", buf, gSettings.triggers[i].action);
+         sprintf(buf, "trigger%dGPIOTypes", i+1);
+         g_key_file_set_integer_list(cfg, "Settings", buf, gSettings.triggers[i].gpiotypes, PISCOPE_GPIOS);
+      }
+   g_key_file_save_to_file(cfg, file, NULL);
+
+   g_free(file);
+   g_key_file_free(cfg);
+}
+
+static int cmpfunc(const void * a, const void * b) {
+   return ( *(int*)a - *(int*)b );
 }
 
 static void pigpioSetGpios(void)
@@ -850,7 +933,8 @@ static void pigpioSetGpios(void)
          case 3:
             gGpioInfo[i].name = gGpioUsage[gRPiRevision-1][i].name;
 
-            if (gGpioUsage[gRPiRevision-1][i].usable)
+            if (gGpioUsage[gRPiRevision-1][i].usable && (!gSettings.activeGPIOs ||
+                  bsearch(&i, gSettings.activeGPIOs, gSettings.activeGPIOCount, sizeof (int), cmpfunc)))
                gGpioInfo[i].display = 1;
 
             break;
@@ -871,6 +955,76 @@ static void pigpioSetGpios(void)
    }
 
    pigpioCommand(gPigSocket, PI_CMD_NB, gPigHandle, notifyBits);
+}
+
+static void util_setTriggerGPIOTypes(int triggerNum)
+{
+   int i, v;
+   uint32_t levelMask;
+   uint32_t changedMask;
+   uint32_t levelValue;
+
+   levelMask    = 0;
+   levelValue   = 0;
+   changedMask  = 0;
+
+   for (i=0; i<PISCOPE_GPIOS; i++)
+   {
+      v = gSettings.triggers[triggerNum].gpiotypes[i];
+      gTrigInfo[triggerNum].type[i] = v;
+
+      switch (v)
+      {
+         case piscope_dont_care:
+            break;
+
+         case piscope_low:
+            levelMask |= (1<<i);
+            break;
+
+         case piscope_high:
+            levelMask  |= (1<<i);
+            levelValue |= (1<<i);
+            break;
+
+         case piscope_edge:
+            changedMask |= (1<<i);
+            break;
+
+         case piscope_falling:
+            levelMask   |= (1<<i);
+            changedMask |= (1<<i);
+            break;
+
+         case piscope_rising:
+            levelMask   |= (1<<i);
+            levelValue  |= (1<<i);
+            changedMask |= (1<<i);
+            break;
+      }
+   }
+
+   gTrigInfo[triggerNum].levelMask = levelMask;
+   gTrigInfo[triggerNum].levelValue = levelValue;
+   gTrigInfo[triggerNum].changedMask = changedMask;
+}
+
+static void pigpioSetTriggers(void)
+{
+   int i;
+
+   sscanf(gTrigSamplesText[gSettings.triggerSamples], "%d", &gTrigSamples);
+   gtk_combo_box_set_active(GTK_COMBO_BOX(gTrgsSamples),  gSettings.triggerSamples);
+
+   for(i=0; i<PISCOPE_TRIGGERS; i++)
+   {
+      gTrigInfo[i].enabled = gSettings.triggers[i].enabled;
+      gTrigInfo[i].when = gSettings.triggers[i].action;
+      util_setTriggerGPIOTypes(i);
+
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(gTrigInfo[i].onW), gTrigInfo[i].enabled);
+      gtk_combo_box_set_active(GTK_COMBO_BOX(gTrigInfo[i].whenW), gTrigInfo[i].when);
+   }
 }
 
 static void pigpioSetState(void)
@@ -973,10 +1127,12 @@ static void pigpioConnect(void)
          util_popupMessage(GTK_MESSAGE_WARNING, GTK_BUTTONS_CLOSE,
             "Can't connect to pigpio.\n" \
             "Did you sudo pigpiod?\n" \
-            "Have you set PIGPIO_ADDR?");
+            "If you are on a remote client, have you set the server address and port in the preferences?");
       }
 
       pigpioSetGpios();
+
+      pigpioSetTriggers();
 
       pigpioSetState();
 
@@ -1029,7 +1185,17 @@ void cmds_clear_triggers_clicked(GtkButton * button, gpointer user_data)
 
 void cmds_close_clicked(GtkButton * button, gpointer user_data)
 {
+   const char *serverAddress;
    gtk_widget_hide(gCmdsDialog);
+
+   g_free(gSettings.serverAddress);
+   gSettings.serverAddress=NULL;
+   serverAddress = gtk_entry_get_text(GTK_ENTRY(gCmdsPigpioAddr));
+   gSettings.serverAddress = g_malloc(strlen(serverAddress)+1);
+   strcpy(gSettings.serverAddress, serverAddress);
+   gSettings.port = strtol(gtk_entry_get_text(GTK_ENTRY(gCmdsPigpioPort)), NULL, 10);
+
+   pigpioSaveSettings();
 }
 
 void cmds_emptybuf_clicked(GtkButton * button, gpointer user_data)
@@ -1077,7 +1243,7 @@ static int file_load(char *filename)
    FILE * in;
    time_t time;
    struct tm cal;
-   char buf[512]; 
+   char buf[512];
 
    err = 1;
 
@@ -1166,7 +1332,7 @@ static int file_save(int filetype, char *filename, int selection)
 
       for (b=0; b<32; b++)
          fprintf(out, "$var wire 1 %c %d $end\n", file_VCDsymbol(b), b);
-        
+
       fprintf(out, "$upscope $end\n");
       fprintf(out, "$enddefinitions $end\n");
    }
@@ -1237,7 +1403,9 @@ void gpio_apply_clicked(GtkButton * button, gpointer user_data)
 
    /* get and set states */
 
-   gDisplayedGpios = 0;
+   g_free(gSettings.activeGPIOs);
+   gSettings.activeGPIOCount = gDisplayedGpios = 0;
+   gSettings.activeGPIOs = g_malloc(PISCOPE_GPIOS * sizeof(gint));
 
    for (i=0; i<PISCOPE_GPIOS; i++)
    {
@@ -1246,6 +1414,7 @@ void gpio_apply_clicked(GtkButton * button, gpointer user_data)
 
       if (gGpioInfo[i].display)
       {
+         gSettings.activeGPIOs[gSettings.activeGPIOCount++] = i;
          gDisplayedGpios++;
 
          notifyBits |= (1<<i);
@@ -1259,11 +1428,15 @@ void gpio_apply_clicked(GtkButton * button, gpointer user_data)
 
       gDisplayedGpios      = 1;
       gGpioInfo[0].display = 1;
+      gSettings.activeGPIOs[0] = 0;
+      gSettings.activeGPIOCount = 1;
    }
 
    pigpioCommand(gPigSocket, PI_CMD_NB, gPigHandle, notifyBits);
 
    util_calcGpioY();
+
+   pigpioSaveSettings();
 }
 
 void gpio_cancel_clicked(GtkButton * button, gpointer user_data)
@@ -1411,64 +1584,42 @@ void trgs_edit4_clicked(GtkButton * button, gpointer user_data)
 
 void trgs_close_clicked(GtkButton * button, gpointer user_data)
 {
+   int i, j;
    gtk_widget_hide(gTrgsDialog);
+
+   for(i=0; i< sizeof(gTrigSamplesText)/sizeof(gTrigSamplesText[0]); i++)
+      {
+         sscanf(gTrigSamplesText[i], "%d", &j);
+         if(j == gTrigSamples)
+            {
+               gSettings.triggerSamples = i;
+               break;
+            }
+      }
+
+   for(i=0; i<PISCOPE_TRIGGERS; i++)
+      {
+         gSettings.triggers[i].enabled = gTrigInfo[i].enabled;
+         gSettings.triggers[i].action = gTrigInfo[i].when;
+         for (j=0; j<PISCOPE_GPIOS; j++)
+            gSettings.triggers[i].gpiotypes[j] = gTrigInfo[i].type[j];
+      }
+   pigpioSaveSettings();
 }
 
 /* TRIG ------------------------------------------------------------------- */
 
 void trig_apply_clicked(GtkButton * button, gpointer user_data)
 {
-   uint32_t levelMask;
-   uint32_t changedMask;
-   uint32_t levelValue;
-   int i, v;
-
-   levelMask    = 0;
-   levelValue   = 0;
-   changedMask  = 0;
+   int i;
 
    if (!gTriggerNum) return;
 
    for (i=0; i<PISCOPE_GPIOS; i++)
-   {
-      v = gtk_combo_box_get_active(GTK_COMBO_BOX(gTrigCombo[i]));
-
-      gTrigInfo[gTriggerNum-1].type[i] = v;
-
-      switch (v)
       {
-         case piscope_dont_care:
-            break;
-
-         case piscope_low:
-            levelMask |= (1<<i);
-            break;
-
-         case piscope_high:
-            levelMask  |= (1<<i);
-            levelValue |= (1<<i);
-            break;
-
-         case piscope_edge:
-            changedMask |= (1<<i);
-            break;
-
-         case piscope_falling:
-            levelMask   |= (1<<i);
-            changedMask |= (1<<i);
-            break;
-
-         case piscope_rising:
-            levelMask   |= (1<<i);
-            levelValue  |= (1<<i);
-            changedMask |= (1<<i);
-            break;
+         gSettings.triggers[gTriggerNum-1].gpiotypes[i] = gtk_combo_box_get_active(GTK_COMBO_BOX(gTrigCombo[i]));
       }
-   }
-
-   gTrigInfo[gTriggerNum-1].levelMask = levelMask;
-   gTrigInfo[gTriggerNum-1].levelValue = levelValue;
-   gTrigInfo[gTriggerNum-1].changedMask = changedMask;
+   util_setTriggerGPIOTypes(gTriggerNum-1);
 
    trgs_lab_str(gTriggerNum-1);
 
@@ -1758,7 +1909,7 @@ static gboolean main_util_input(gpointer user_data)
       }
 
       /* copy any partial report to start of array */
-      
+
       if (got && r) gReport[0] = gReport[r];
    }
 
@@ -2473,7 +2624,7 @@ gboolean main_osc_motion_notify_event(
 
    }
 
-   return TRUE; 
+   return TRUE;
 }
 
 gboolean main_osc_button_press_event(
@@ -2511,7 +2662,7 @@ gboolean main_osc_button_press_event(
       gViewCentreTick += ticks;
    }
 
-  return TRUE; 
+  return TRUE;
 }
 
 
@@ -2555,7 +2706,7 @@ gboolean main_samp_button_press_event(
       main_util_labelTick(&gGoldTick, gMainLgold);
    }
 
-  return TRUE; 
+  return TRUE;
 }
 
 void main_samp_configure_event
@@ -2710,13 +2861,13 @@ void main_menu_file_save(GtkMenuItem *menuitem, int selection)
          if (strcasecmp(".vcd", filename + strlen(filename) - 4) == 0)
             textfile = 0;
       }
-     
+
       if (strlen(filename) > 7)
       {
          if (strcasecmp(".piscope", filename + strlen(filename) - 8) == 0)
             textfile = 1;
       }
-     
+
       if (textfile)
          file_save(piscope_text, filename, selection);
       else
@@ -3013,7 +3164,7 @@ gboolean main_vleg_button_press_event(
       }
    }
 
-  return TRUE; 
+  return TRUE;
 }
 
 /* MAIN KEY --------------------------------------------------------------- */
@@ -3119,7 +3270,7 @@ gboolean main_key_press_event(
          break;
    }
 
-  return FALSE; 
+  return FALSE;
 }
 
 
@@ -3134,6 +3285,8 @@ int main(int argc, char *argv[])
    int  i, j, ui_ok;
 
    gtk_init(&argc, &argv);
+
+   pigpioLoadSettings();
 
   /* Construct a GtkBuilder instance and load our UI description */
 
@@ -3336,4 +3489,3 @@ int main(int argc, char *argv[])
 
    return 0;
 }
-

--- a/piscope.h
+++ b/piscope.h
@@ -30,7 +30,10 @@ For more information, please refer to <http://unlicense.org/>
 
 /* from pigpio pigpio.h */
 
-#define PI_DEFAULT_SERVER_ADDRESS "127.0.0.1"
+#define PI_ENVPORT "PIGPIO_PORT"
+#define PI_ENVADDR "PIGPIO_ADDR"
+
+#define PI_DEFAULT_SERVER_ADDRESS "localhost"
 #define PI_DEFAULT_SOCKET_PORT 8888
 
 #define SETTINGS_FILE_NAME "piscope.conf"

--- a/piscope.h
+++ b/piscope.h
@@ -33,6 +33,16 @@ For more information, please refer to <http://unlicense.org/>
 #define PI_DEFAULT_SERVER_ADDRESS "127.0.0.1"
 #define PI_DEFAULT_SOCKET_PORT 8888
 
+#define SETTINGS_FILE_NAME "piscope.conf"
+#define SETTINGS_GROUP "Settings"
+#define SETTINGS_SERVER_ADDRESS "serverAddress"
+#define SETTINGS_SERVER_PORT "serverPort"
+#define SETTINGS_ACTIVE_GPIOS "activeGPIOs"
+#define SETTINGS_TRIGGER_SAMPLES "triggerSamples"
+#define SETTINGS_TRIGGER_ENABLED "trigger%dEnabled"
+#define SETTINGS_TRIGGER_ACTION "trigger%dAction"
+#define SETTINGS_TRIGGER_GPIO_TYPES "trigger%dGPIOTypes"
+
 #define PI_CMD_HWVER 17
 #define PI_CMD_NB    19
 #define PI_CMD_NC    21

--- a/piscope.h
+++ b/piscope.h
@@ -30,9 +30,7 @@ For more information, please refer to <http://unlicense.org/>
 
 /* from pigpio pigpio.h */
 
-#define PI_ENVPORT "PIGPIO_PORT"
-#define PI_ENVADDR "PIGPIO_ADDR"
-
+#define PI_DEFAULT_SERVER_ADDRESS "127.0.0.1"
 #define PI_DEFAULT_SOCKET_PORT 8888
 
 #define PI_CMD_HWVER 17


### PR DESCRIPTION
Added settings load&save capabilities in the user's config directory.
Will save the following parameters:
- Server Address
- Server Port
- Active GPIOs
- Trigger Samples
- For each trigger:
  - Enabled flag
  - Action (when)
  - For each GPIO port:
    - Trigger type

The environment variables are still supported, taking precedence over custom preferences.